### PR TITLE
Fix typos and markdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,29 @@ Use Elixir's IEx helpers from the command line.
 
 Use `mix`:
 
-```
+```sh
 mix escript.install github rowlandcodes/exhelp tag v0.3.0
 ```
 
 If you use `asdf` as a version manager, make sure to run:
 
-```
+```sh
 asdf reshim
 ```
 
 ## Features
 
-* Fetch documentation for a module or function
-* Open a module or function in an editor
-* Fetch types defined in a module
-* Fetch behaviours defined in a module
-* List exported functions and macros from a module
-* Search for modules or functions
-* Mix integration: Use Exhelp with projects and dependencies
+- Fetch documentation for a module or function
+- Open a module or function in an editor
+- Fetch types defined in a module
+- Fetch behaviours defined in a module
+- List exported functions and macros from a module
+- Search for modules or functions
+- Mix integration: Use Exhelp with projects and dependencies
 
 ## Usage
 
-```
+```sh
 Usage:
   exh QUERY [OPTIONS]
 
@@ -52,7 +52,7 @@ Options:
                          Exclusive with QUERY or --all-modules
       --exports          Displays the exports from queried Module
       --version          Print Exhelp version
-  -S mix                 Enables mix integration allowing exh to work on 
+  -S mix                 Enables mix integration allowing exh to work on
                          project and dependency queries.
 ```
 
@@ -61,7 +61,7 @@ Options:
 Without a flag, `exh` display documentation for a query.
 This mimics `IEx.Helpers.h/1`.
 
-```
+```sh
 # Fetch documentation for a module
 exh GenServer
 
@@ -83,11 +83,11 @@ but you will need to have Erlang documentation installed.
 The flag `-o` or `--open` will open your query in editor.
 This mimics `IEx.Helpers.open/1`.
 
-```
+```sh
 # Open a module
 iex Enum -o
 
-# Open a module at a function defintion
+# Open a module at a function definition
 iex :lists.map --open
 
 # Open a module at a specific function arity
@@ -98,11 +98,11 @@ iex is_function -o
 ```
 
 **Note**: Open works by using the `ELIXIR_EDITOR` environmental variable,
-falling back to `EDITOR`. But if you use a terminal editor, 
+falling back to `EDITOR`. But if you use a terminal editor,
 Elixir doesn't want to hand over control of the tty,
 so you'll need to set `ELIXIR_EDITOR` to open in a new terminal:
 
-```
+```sh
 # For the terminal editor kakoune and terminal xterm
 # __LINE__ and __FILE__ are replaced with the appropriate value by exh
 # Set them appropriately for your editor to understand them
@@ -117,7 +117,7 @@ exh -o Enum.map/2
 The flag `-t` or `--type` will list the types that were defined in a module.
 This mimics `IEx.Helpers.t/1`.
 
-```
+```sh
 # -t only works with a Module as the query
 exh -t Enum
 
@@ -130,7 +130,7 @@ exh :erlang --type
 The flag `-b` or `--behaviour` will list the behaviours that were defined in a module.
 This mimics `IEx.Helpers.b/1`.
 
-```
+```sh
 # -b only works with a Module as the query
 exh -b GenServer
 
@@ -143,7 +143,7 @@ exh -b :gen_server
 The flag `--exports` will list all public functions and macros exported by a module.
 This mimics `IEx.Helpers.exports/1`.
 
-```
+```sh
 # --exports only works with a Module as the query
 exh --exports Enum
 ```
@@ -153,7 +153,7 @@ exh --exports Enum
 The flag `-s` or `--search` allows you to search for modules or functions.
 It will list all Modules or functions that begin with your query.
 
-```
+```sh
 # Search for modules that start with Enu
 exh -s Enu
 
@@ -162,17 +162,17 @@ exh --search Enum.ma
 
 # Search for functions in any loaded module that start with ma
 exh --search ma
-``` 
+```
 
 The `--search` flag also supports two special option flags,
 which are used in place of a query:
 
-* `--all-modules`: Which lists all loaded modules
-* `--all-functions`: Which lists every exported function from every loaded module.
+- `--all-modules`: Which lists all loaded modules
+- `--all-functions`: Which lists every exported function from every loaded module.
 
 These flags are designed to be used with other unix tools:
 
-```
+```sh
 # Enable fine-grained search with grep
 exh -s --all-modules | grep Enum
 
@@ -188,11 +188,11 @@ Mix integration will only work if there is an `mix.exs` file in the current dire
 
 Calling `exh` with Mix will compile your project.
 
-```
+```sh
 # Read dependency documentation
 exh Witchcraft -S mix | less -R
 
-# Open a downloaded libary module
+# Open a downloaded library module
 exh -S mix --open Phoenix.Router
 
 # List types from a library module
@@ -208,7 +208,8 @@ exh -S mix --exports Tco
 exh -S mix --search Zig
 ```
 
-If you set `EXHELP_ENABLE_MIX=true`, Exhelp will automatically connect to Mix when it detects a `mix.exs` in the directory.
+If you set `EXHELP_ENABLE_MIX=true`, Exhelp will automatically connect to Mix
+when it detects a `mix.exs` in the directory.
 
 ## Configuration
 
@@ -219,7 +220,7 @@ This is overridden if there is a local `.iex.exs` file in the project directory.
 If you would like to ignore `.iex.exs` configuration and use default colors,
 set `EXHELP_ENABLE_DOT_IEX=false`.
 
-```
+```sh
 # Further reading: IEx's section on .iex.exs
 exh IEx
 


### PR DESCRIPTION
Found via these commands:

    codespell .
    markdownlint README.md